### PR TITLE
Fix setup.py to work on Ubuntu 14.04 (and possibly other OSes)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.pyc
 dist
 build
+define.egg-info

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from distutils.core import setup
+from setuptools import setup
 
 setup(name='define',
       description='Terminal Dictionary',


### PR DESCRIPTION
When I tried installing define with 

<code>sudo python setup.py install</code>

My terminal puked out a error message

<code>/usr/lib/python2.7/distutils/dist.py:267: UserWarning: Unknown distribution option: 'install_requires'</code>

After some researching, it turns out that either we could change the code from distutils to setuptools which I did, or we could change the code from <code>install_requires=</code> to <code>requires=</code> which is described [here](https://doughellmann.com/blog/2007/11/25/requiring-packages-with-distutils/)
