### PR TITLE
fix list index out of range for local

### DIFF
--- a/define
+++ b/define
@@ -250,7 +250,10 @@ def print_each_definition(words, client, optional_args):
             else:
                 print(client.getDefinition(word, "wordnet"))
         elif local:
-            print(getLocalDefinition(word)[0])
+            try:
+                print(getLocalDefinition(word)[0])
+            except IndexError:
+                print("Definition Not Found")
         elif wiktionary:
             print(client.getDefinition(word, "wiktionary"))
         else:

--- a/define
+++ b/define
@@ -26,19 +26,22 @@ class dict:
 
     def getDefinition(self, word, source="all"):
         definition = requests.get(
-            "http://api.wordnik.com/v4/word.json/%s/definitions?limit=1&api_key=%s&caseSensitive=false&useCanonical=true&sourceDictionaries=%s" % (word, self.key, source)).json()
+            "http://api.wordnik.com/v4/word.json/%s/definitions?limit=1"
+            "&api_key=%s&caseSensitive=false&useCanonical=true&"
+            "sourceDictionaries=%s" % (word, self.key, source)).json()
         if len(definition) >= 1:
             return definition[0]["text"]
         return definition
 
     def getHyphenation(self, word):
         hyphenation = requests.get(
-            "http://api.wordnik.com/v4/word.json/%s/hyphenation?api_key=%s" % (word, self.key)).json()
+            "http://api.wordnik.com/v4/word.json/%s/hyphenation?api_key=%s"
+            % (word, self.key)).json()
         return hyphenation
 
     def getAudio(self, word):
-        url = requests.get("http://api.wordnik.com/v4/word.json/%s/audio?api_key=%s" %
-                           (word, self.key)).json()
+        url = requests.get("http://api.wordnik.com/v4/word.json/%s/audio?"
+                           "api_key=%s" % (word, self.key)).json()
         if len(url) >= 1:
             url = url[0]["fileUrl"]
         else:
@@ -46,8 +49,10 @@ class dict:
         return True, url, requests.get(url)
 
     def getUrban(self, word):
-        urb = requests.get("https://mashape-community-urban-dictionary.p.mashape.com/define?term=%s"
-                           % word, headers={"X-Mashape-Key": self.urbankey}).json()
+        urb = requests.get("https://mashape-community-urban-dictionary.p."
+                           "mashape.com/define?term=%s"
+                           % word, headers={"X-Mashape-Key":
+                                            self.urbankey}).json()
         if len(urb["list"]) > 0:
             return urb["list"][0]["definition"]
 
@@ -56,11 +61,15 @@ class dict:
                             % (self.tkey, word)).json()
         return response"""
         response = requests.get(
-            "http://api.wordnik.com:80/v4/word.json/%s/relatedWords?useCanonical=false&relationshipTypes=synonym&limitPerRelationshipType=15&api_key=%s" % (word, key)).json()
+            "http://api.wordnik.com:80/v4/word.json/%s/relatedWords?"
+            "useCanonical=false&relationshipTypes=synonym&limitPer"
+            "RelationshipType=15&api_key=%s" % (word, key)).json()
         return response[0]
 
 
-def which(program):  # credit to http://stackoverflow.com/questions/377017/test-if-executable-exists-in-python
+# credit to
+# http://stackoverflow.com/questions/377017/test-if-executable-exists-in-python
+def which(program):
     import os
 
     def is_exe(fpath):
@@ -199,7 +208,8 @@ def getLocalDefinition(word):
                 for a, b in enumerate(lines[i:]):
                     if b.startswith("        ["):
                         endline = a + i
-                        definitions.append(" ".join(lines[i:endline]).replace("        ", "")[8:])
+                        definitions.append(" ".join(lines[i:endline])
+                                           .replace("        ", "")[8:])
                         # print(lines[i:endline])
                         break
     return definitions

--- a/define
+++ b/define
@@ -12,9 +12,9 @@ tkey = "e415520c671c26518df498d8f4736cac"
 urbankey = "ub2JDDg9Iumsh1HfdO3a3HQbZi0up1qe8LkjsnWQvyVvQLFn1q"
 hyphenation = False  # Disable or Enable Hyphenation
 try:
-        raw_input_ = raw_input
+    raw_input_ = raw_input
 except NameError:
-        raw_input_ = input
+    raw_input_ = input
 
 
 class dict:
@@ -82,7 +82,8 @@ def which(program):  # credit to http://stackoverflow.com/questions/377017/test-
 
 def getLocalWordnet(word):
     definitions = []
-    output = subprocess.Popen(["wn", word, "-over"], stdout=subprocess.PIPE).communicate()[0]
+    output = subprocess.Popen(["wn", word, "-over"],
+                              stdout=subprocess.PIPE).communicate()[0]
     for line in output.split("\n"):
         reg = regex.search(line)
         if reg:
@@ -99,14 +100,18 @@ defined as well as the actual argument defined"""
 def get_args():
     arg = optparse.OptionParser()
     arg.add_option("-a", "--audio", action="store_true",
-                   help='audio playback for the the search result', default=False)
+                   help='audio playback for the the search result',
+                   default=False)
     arg.add_option("-t", "--thesaurus", action="store_true",
                    help='show search results using thesaurus', default=False)
     arg.add_option("-u", "--urban", action="store_true",
-                   help='show search results using urbandictionary.com', default=False)
-    arg.add_option("-w", "--wordnet", action="store_true", help='show search results using wordnet')
+                   help='show search results using urbandictionary.com',
+                   default=False)
+    arg.add_option("-w", "--wordnet", action="store_true",
+                   help='show search results using wordnet')
     arg.add_option("-l", "--local", action="store_true",
-                   help='show search results using local dict and dictd dictionary', default=False)
+                   help='show search results using local dict and dictd',
+                   default=False)
     arg.add_option("-k", "--wiktionary", action="store_true",
                    help='show search results using wiktionary')
     return arg.parse_args(argv)
@@ -169,7 +174,8 @@ def print_wordnik_definition(word, client):
     except requests.exceptions.ConnectionError:
         if which("dict") != None:
             fallback = raw_input_(
-                "There was a connection error, but dict was detected. Would you like to use dict? [y/N] ")
+                "There was a connection error, but dict was detected. \
+                        Would you like to use dict? [y/N] ")
             if fallback.lower().startswith("y"):
                 definitions = getLocalDefinition(word)
                 if len(definitions) >= 1:
@@ -200,7 +206,7 @@ def getLocalDefinition(word):
 
 
 def getWordnet(word):
-    definitions = Word(word).definitions
+    definitions = word(word).definitions
     if len(definitions) >= 1:
         return definitions[0]
 


### PR DESCRIPTION
This is a simple use case, try to search with local using:
`define -l rage` then repeat the same search with
`define -l ragee` and you get the error:
`IndexError: list index out of range`
This is ofc not ideal, so added a simple except.
